### PR TITLE
create secret for metallb speaker

### DIFF
--- a/packages/metal-lb/package.json
+++ b/packages/metal-lb/package.json
@@ -18,7 +18,8 @@
   },
   "peerDependencies": {
     "@pulumi/kubernetes": "*",
-    "@pulumi/pulumi": "*"
+    "@pulumi/pulumi": "*",
+    "@pulumi/random": "*"
   },
   "dependencies": {
     "@kloudlib/abstractions": "*"


### PR DESCRIPTION
Create a secret for metallb speaker since the pre-install hook used
in the bitnami chart prevents creation by pulumi helm v3 provider

fixes Place1/kloudlib#27